### PR TITLE
test: update tests to support latest google-cloud-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "3.0.1"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
-    "google-cloud-core >= 1.1.0, < 2.0dev",
+    "google-cloud-core == 1.4.2rc1",
     "libcst >= 0.2.5",
     "proto-plus >= 0.4.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "3.0.1"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
-    "google-cloud-core == 1.4.2rc1",
+    "google-cloud-core == 1.4.2rc2",
     "libcst >= 0.2.5",
     "proto-plus >= 0.4.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "3.0.1"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
-    "google-cloud-core == 1.4.2rc2",
+    "google-cloud-core >= 1.1.0, < 2.0dev",
     "libcst >= 0.2.5",
     "proto-plus >= 0.4.0",
 ]

--- a/tests/unit/v2/test__http.py
+++ b/tests/unit/v2/test__http.py
@@ -28,27 +28,56 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one(object())
-        URI = "/".join(
-            [
-                conn.DEFAULT_API_ENDPOINT,
-                "language",
-                "translate",
-                conn.API_VERSION,
-                "foo",
-            ]
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(
+            path,
+            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         )
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         custom_endpoint = "https://foo-translation.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join(
-            [custom_endpoint, "language", "translate", conn.API_VERSION, "foo"]
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(
+            path,
+            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         )
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
+        conn = self._make_one(object())
+        uri = conn.build_api_url("/foo", {"bar": "baz"})
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(
+            path,
+            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
+        )
+        parms = dict(parse_qsl(qs))
+        self.assertEqual(parms["bar"], "baz")
+
+    def test_build_api_url_w_extra_query_params_tuple(self):
         from six.moves.urllib.parse import parse_qsl
         from six.moves.urllib.parse import urlsplit
 
@@ -59,8 +88,9 @@ class TestConnection(unittest.TestCase):
         self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
         expected_path = "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         self.assertEqual(path, expected_path)
-        params = parse_qsl(qs)
-        self.assertEqual(params, query_params)
+        params = list(sorted(param for param in parse_qsl(qs) if param[0] != "prettyPrint"))
+        expected_params = [("q", "val1"), ("q", "val2")]
+        self.assertEqual(params, expected_params)
 
     def test_extra_headers(self):
         import requests

--- a/tests/unit/v2/test__http.py
+++ b/tests/unit/v2/test__http.py
@@ -36,8 +36,7 @@ class TestConnection(unittest.TestCase):
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
         self.assertEqual(
-            path,
-            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
+            path, "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         )
         parms = dict(parse_qsl(qs))
         pretty_print = parms.pop("prettyPrint", "false")
@@ -54,8 +53,7 @@ class TestConnection(unittest.TestCase):
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
         self.assertEqual(
-            path,
-            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
+            path, "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         )
         parms = dict(parse_qsl(qs))
         pretty_print = parms.pop("prettyPrint", "false")
@@ -71,8 +69,7 @@ class TestConnection(unittest.TestCase):
         scheme, netloc, path, qs, _ = urlsplit(uri)
         self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
         self.assertEqual(
-            path,
-            "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
+            path, "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         )
         parms = dict(parse_qsl(qs))
         self.assertEqual(parms["bar"], "baz")
@@ -88,7 +85,9 @@ class TestConnection(unittest.TestCase):
         self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
         expected_path = "/".join(["", "language", "translate", conn.API_VERSION, "foo"])
         self.assertEqual(path, expected_path)
-        params = list(sorted(param for param in parse_qsl(qs) if param[0] != "prettyPrint"))
+        params = list(
+            sorted(param for param in parse_qsl(qs) if param[0] != "prettyPrint")
+        )
         expected_params = [("q", "val1"), ("q", "val2")]
         self.assertEqual(params, expected_params)
 


### PR DESCRIPTION
`google-cloud-core` version 1.4.2 populates `prettyPrint=false` by
default. Update the connection tests to expect a value for
`prettyPrint`.

`test_build_api_url_w_extra_query_params_tuple` unit test is currently failing, but will be fixed by https://github.com/googleapis/python-cloud-core/pull/34

This pull request is to check that the changes made in googleapis/python-cloud-core#28 do not break this library.