### PR TITLE
chore: fixed wrong method name

### DIFF
--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
@@ -54,7 +54,6 @@ def glossary():
     delete_glossary()
 
 
-
 @pytest.fixture(scope="function")
 def bucket():
     """Create a temporary bucket to store annotation output."""

--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
@@ -15,7 +15,10 @@
 import os
 import uuid
 
+import backoff
+from google.api_core.exceptions import DeadlineExceeded, GoogleAPICallError
 from google.cloud import storage
+from google.cloud.exceptions import NotFound
 import pytest
 
 import translate_v3_batch_translate_text_with_glossary_and_model
@@ -37,16 +40,25 @@ def glossary():
 
     yield glossary_id
 
-    try:
-        translate_v3_delete_glossary.sample_delete_glossary(PROJECT_ID, glossary_id)
-    except Exception:
-        pass
+    # clean up
+    @backoff.on_exception(
+        backoff.expo, (DeadlineExceeded, GoogleAPICallError), max_time=60
+    )
+    def delete_glossary():
+        try:
+            translate_v3_delete_glossary.delete_glossary(PROJECT_ID, glossary_id)
+        except NotFound as e:
+            # Ignoring this case.
+            print("Got NotFound, detail: {}".format(str(e)))
+
+    delete_glossary()
+
 
 
 @pytest.fixture(scope="function")
 def bucket():
     """Create a temporary bucket to store annotation output."""
-    bucket_name = "mike-test-delete-" + str(uuid.uuid1())
+    bucket_name = "test-bucket-for-glossary-" + str(uuid.uuid1())
     storage_client = storage.Client()
     bucket = storage_client.create_bucket(bucket_name)
 

--- a/samples/snippets/translate_v3_batch_translate_text_with_model.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_model.py
@@ -24,7 +24,7 @@ def batch_translate_text_with_model(
     model_id="YOUR_MODEL_ID",
 ):
     """Batch translate text using Translation model.
-     Model can be AutoML or General[built-in] model. """
+    Model can be AutoML or General[built-in] model."""
 
     client = translate.TranslationServiceClient()
 

--- a/samples/snippets/translate_v3_delete_glossary.py
+++ b/samples/snippets/translate_v3_delete_glossary.py
@@ -17,7 +17,9 @@ from google.cloud import translate_v3 as translate
 
 
 def delete_glossary(
-    project_id="YOUR_PROJECT_ID", glossary_id="YOUR_GLOSSARY_ID", timeout=180,
+    project_id="YOUR_PROJECT_ID",
+    glossary_id="YOUR_GLOSSARY_ID",
+    timeout=180,
 ):
     """Delete a specific glossary based on the glossary ID."""
     client = translate.TranslationServiceClient()


### PR DESCRIPTION
Due to wrong method usage one method, it led to glossary max [1000] from not deleting glossary in the teardown.
Fixes #95, #96, #97, #98 🦕
