### PR TITLE
chore: adds cdpe-cloudai as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 *               @googleapis/yoshi-python
 
 # The @googleapis/cdpe-cloudai own the samples
-*               @googleapis/cdpe-cloudai
+/samples/**/*.py                       @googleapis/cdpe-cloudai
 
 # The python-samples-owners team is the default owner for samples
 /samples/**/*.py                       @telpirion @sirtorry @googleapis/python-samples-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # The @googleapis/yoshi-python is the default owner for changes in this repo
 *               @googleapis/yoshi-python
 
+# The @googleapis/cdpe-cloudai own the samples
+*               @googleapis/cdpe-cloudai
 
 # The python-samples-owners team is the default owner for samples
 /samples/**/*.py                       @telpirion @sirtorry @googleapis/python-samples-owners


### PR DESCRIPTION
This PR allows the @googleapis/cdpe-cloudai team to approve changes to this repo.
