### PR TITLE
chore: renamed output dir to prevent bucket concurrency error

### DIFF
--- a/samples/snippets/beta_snippets_test.py
+++ b/samples/snippets/beta_snippets_test.py
@@ -75,7 +75,7 @@ def test_batch_translate_text(capsys, bucket):
     beta_snippets.batch_translate_text(
         PROJECT_ID,
         "gs://cloud-samples-data/translation/text.txt",
-        "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
+        "gs://{}/translation/BATCH_TRANSLATION_BETA_OUTPUT/".format(bucket.name),
     )
     out, _ = capsys.readouterr()
     assert "Total Characters: 13" in out

--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
@@ -69,7 +69,7 @@ def bucket():
 def test_batch_translate_text_with_glossary_and_model(capsys, bucket, glossary):
     translate_v3_batch_translate_text_with_glossary_and_model.batch_translate_text_with_glossary_and_model(
         "gs://cloud-samples-data/translation/text_with_custom_model_and_glossary.txt",
-        "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
+        "gs://{}/translation/BATCH_TRANSLATION_GLOS_MODEL_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         MODEL_ID,
         glossary,

--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
@@ -70,7 +70,7 @@ def bucket():
 def test_batch_translate_text_with_glossary(capsys, bucket, glossary):
     translate_v3_batch_translate_text_with_glossary.batch_translate_text_with_glossary(
         "gs://cloud-samples-data/translation/text_with_glossary.txt",
-        "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
+        "gs://{}/translation/BATCH_TRANSLATION_GLOS_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         glossary,
         320,

--- a/samples/snippets/translate_v3_batch_translate_text_with_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_model_test.py
@@ -40,7 +40,7 @@ def bucket():
 def test_batch_translate_text_with_model(capsys, bucket):
     translate_v3_batch_translate_text_with_model.batch_translate_text_with_model(
         "gs://cloud-samples-data/translation/custom_model_text.txt",
-        "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
+        "gs://{}/translation/BATCH_TRANSLATION_MODEL_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         MODEL_ID,
     )


### PR DESCRIPTION

Fixes #115, #116 🦕
