### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,20 @@ import os
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
 
 # Package metadata.
 
@@ -60,7 +74,7 @@ if "google.cloud" in packages:
 
 setuptools.setup(
     name=name,
-    version=setuptools.sic(version),
+    version=sic(version),
     description=description,
     long_description=readme,
     author="Google LLC",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ if "google.cloud" in packages:
 
 setuptools.setup(
     name=name,
-    version=version,
+    version=setuptools.sic(version),
     description=description,
     long_description=readme,
     author="Google LLC",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.