### PR TITLE
docs: connect Python Translate client library to nebulous serverless example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Windows
 Samples
 -----------
 
-The `samples`__ folder contains all of the Cloud Translation API code snippets
+The `samples folder`_ contains all of the Cloud Translation API code snippets
 found in `its documentation`_ as well as complete sample apps:
 
 - `Mini Google Translate "MVP"`_ app
@@ -96,7 +96,7 @@ found in `its documentation`_ as well as complete sample apps:
   - Deployable locally or any on-prem or cloud host supporting Flask apps
   - Also deployable to `Google Cloud serverless hosting platforms`_ (`App Engine`_, `Cloud Functions`_, or `Cloud Run`_) with only minor configuration changes
 
-.. _samples: samples
+.. _samples folder: samples
 .. _its documentation: https://cloud.google.com/translate/docs
 .. _Mini Google Translate "MVP": https://github.com/googlecodelabs/cloud-nebulous-serverless-python
 .. _Google Cloud serverless hosting platforms: https://cloud.google.com/serverless#serverless-products

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Windows
 Samples
 -----------
 
-The `samples`_ folder contains all of the Cloud Translation API code snippets
+The `samples`__ folder contains all of the Cloud Translation API code snippets
 found in `its documentation`_ as well as complete sample apps:
 
 - `Mini Google Translate "MVP"`_ app

--- a/README.rst
+++ b/README.rst
@@ -90,15 +90,15 @@ Samples
 The `samples`_ folder contains all of the Cloud Translation API code snippets
 found in `its documentation`_ as well as complete sample apps:
 
-- `Mini-Google Translate "MVP"`_ app
+- `Mini Google Translate "MVP"`_ app
+
   - Shows how to use the API in a Python/Flask web app
   - Deployable locally or any on-prem or cloud host supporting Flask apps
-  - Also deployable to `Google Cloud serverless hosting platforms`_:
-      - `App Engine`_, `Cloud Functions`_, or `Cloud Run`_ with only minor configuration changes
+  - Also deployable to `Google Cloud serverless hosting platforms`_ (`App Engine`_, `Cloud Functions`_, or `Cloud Run`_) with only minor configuration changes
 
 .. _samples: samples
 .. _its documentation: https://cloud.google.com/translate/docs
-.. _"Mini Google Translate MVP" Flask web app: https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+.. _Mini Google Translate "MVP": https://github.com/googlecodelabs/cloud-nebulous-serverless-python
 .. _Google Cloud serverless hosting platforms: https://cloud.google.com/serverless#serverless-products
 .. _App Engine: https://cloud.google.com/appengine
 .. _Cloud Functions: https://cloud.google.com/functions

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ found in `its documentation`_ as well as complete sample apps utilizing the API:
 
 - `"Mini Google Translate MVP" Flask web app`_ &mdash; any host or Google Cloud: `App Engine`_, `Cloud Functions`_, or `Cloud Run`_
 
-.. _samples: /tree/master/samples
+.. _samples: samples
 .. _its documentation: https://cloud.google.com/translate/docs
 .. _"Mini Google Translate MVP" web app: https://github.com/googlecodelabs/cloud-nebulous-serverless-python
 .. _App Engine: https://cloud.google.com/appengine

--- a/README.rst
+++ b/README.rst
@@ -90,11 +90,11 @@ Samples
 The `samples`_ folder contains all of the Cloud Translation API code snippets
 found in `its documentation`_ as well as complete sample apps utilizing the API:
 
-- `"Mini Google Translate MVP" Flask web app`_ &mdash; any host or Google Cloud: `App Engine`_, `Cloud Functions`_, or `Cloud Run`_
+- `"Mini Google Translate MVP" Flask web app`_ (any host or Google Cloud: `App Engine`_, `Cloud Functions`_, or `Cloud Run`_)
 
 .. _samples: samples
 .. _its documentation: https://cloud.google.com/translate/docs
-.. _"Mini Google Translate MVP" web app: https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+.. _"Mini Google Translate MVP" Flask web app: samples/cloud-nebulous-serverless-python
 .. _App Engine: https://cloud.google.com/appengine
 .. _Cloud Functions: https://cloud.google.com/functions
 .. _Cloud Run: https://cloud.google.com/run

--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,19 @@ Windows
     virtualenv <your-env>
     <your-env>\Scripts\activate
     <your-env>\Scripts\pip.exe install google-cloud-translate
+
+Samples
+-----------
+
+The `samples`_ folder contains all of the Cloud Translation API code snippets
+found in `its documentation`_ as well as complete sample apps utilizing the API:
+
+- `"Mini Google Translate MVP" Flask web app`_ &mdash; any host or Google Cloud: `App Engine`_, `Cloud Functions`_, or `Cloud Run`_
+
+.. _samples: /tree/master/samples
+.. _its documentation: https://cloud.google.com/translate/docs
+.. _"Mini Google Translate MVP" web app: https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+.. _App Engine: https://cloud.google.com/appengine
+.. _Cloud Functions: https://cloud.google.com/functions
+.. _Cloud Run: https://cloud.google.com/run
+

--- a/README.rst
+++ b/README.rst
@@ -88,13 +88,18 @@ Samples
 -----------
 
 The `samples`_ folder contains all of the Cloud Translation API code snippets
-found in `its documentation`_ as well as complete sample apps utilizing the API:
+found in `its documentation`_ as well as complete sample apps:
 
-- `"Mini Google Translate MVP" Flask web app`_ (any host or Google Cloud: `App Engine`_, `Cloud Functions`_, or `Cloud Run`_)
+- `Mini-Google Translate "MVP"`_ app
+  - Shows how to use the API in a Python/Flask web app
+  - Deployable locally or any on-prem or cloud host supporting Flask apps
+  - Also deployable to `Google Cloud serverless hosting platforms`_:
+      - `App Engine`_, `Cloud Functions`_, or `Cloud Run`_ with only minor configuration changes
 
 .. _samples: samples
 .. _its documentation: https://cloud.google.com/translate/docs
-.. _"Mini Google Translate MVP" Flask web app: samples/cloud-nebulous-serverless-python
+.. _"Mini Google Translate MVP" Flask web app: https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+.. _Google Cloud serverless hosting platforms: https://cloud.google.com/serverless#serverless-products
 .. _App Engine: https://cloud.google.com/appengine
 .. _Cloud Functions: https://cloud.google.com/functions
 .. _Cloud Run: https://cloud.google.com/run

--- a/samples/cloud-nebulous-serverless-python/README.md
+++ b/samples/cloud-nebulous-serverless-python/README.md
@@ -1,3 +1,1 @@
-For a complete sample Python "mini-Google Translate" web app using the [Google Cloud Translation API](https://cloud.google.com/translate), go to <https://github.com/googlecodelabs/cloud-nebulous-serverless-python>.
-
-In addition to local or hosting service deployments, the app can be deployed to any of the [Google Cloud serverless](https://cloud.google.com/serverless) compute platforms, [Google App Engine](https://cloud.google.com/appengine), [Cloud Functions](https://cloud.google.com/functions), or [Cloud Run](https://cloud.google.com/run), with just minor configuration changes.
+This sample can be found at <https://github.com/googlecodelabs/cloud-nebulous-serverless-python>.

--- a/samples/cloud-nebulous-serverless-python/README.md
+++ b/samples/cloud-nebulous-serverless-python/README.md
@@ -1,3 +1,3 @@
-For a sample Python "mini-Google Translate" web app using the [Google Cloud Translation API](https://cloud.google.com/translate), go to https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+For a complete sample Python "mini-Google Translate" web app using the [Google Cloud Translation API](https://cloud.google.com/translate), go to <https://github.com/googlecodelabs/cloud-nebulous-serverless-python>.
 
-The app can be deployed locally via the Flask development server, or to any [Google Cloud serverless](https://cloud.google.com/serverless) compute platforms, [Google App Engine](https://cloud.google.com/appengine), [Cloud Functions](https://cloud.google.com/functions), or [Cloud Run](https://cloud.google.com/run), with just minor configuration changes.
+In addition to local or hosting service deployments, the app can be deployed to any of the [Google Cloud serverless](https://cloud.google.com/serverless) compute platforms, [Google App Engine](https://cloud.google.com/appengine), [Cloud Functions](https://cloud.google.com/functions), or [Cloud Run](https://cloud.google.com/run), with just minor configuration changes.

--- a/samples/cloud-nebulous-serverless-python/README.md
+++ b/samples/cloud-nebulous-serverless-python/README.md
@@ -1,0 +1,3 @@
+For a sample Python "mini-Google Translate" web app using the [Google Cloud Translation API](https://cloud.google.com/translate), go to https://github.com/googlecodelabs/cloud-nebulous-serverless-python
+
+The app can be deployed locally via the Flask development server, or to any [Google Cloud serverless](https://cloud.google.com/serverless) compute platforms, [Google App Engine](https://cloud.google.com/appengine), [Cloud Functions](https://cloud.google.com/functions), or [Cloud Run](https://cloud.google.com/run), with just minor configuration changes.


### PR DESCRIPTION
Not adding new code but linking to another repo with a sample app using this API as another sample for users; added folder with README per @busunkim96 