### PR TITLE
samples: changed v1beta1 AutoML model for v1

### DIFF
--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_and_model_test.py
@@ -22,7 +22,7 @@ import translate_v3_batch_translate_text_with_glossary_and_model
 
 PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
 GLOSSARY_ID = "DO_NOT_DELETE_TEST_GLOSSARY"
-MODEL_ID = "TRL3128559826197068699"
+MODEL_ID = "TRL251293382528204800"
 
 
 @pytest.fixture(scope="function")

--- a/samples/snippets/translate_v3_batch_translate_text_with_model_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_model_test.py
@@ -22,7 +22,7 @@ import translate_v3_batch_translate_text_with_model
 
 
 PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
-MODEL_ID = "TRL3128559826197068699"
+MODEL_ID = "TRL251293382528204800"
 
 
 @pytest.fixture(scope="function")

--- a/samples/snippets/translate_v3_translate_text_with_model_test.py
+++ b/samples/snippets/translate_v3_translate_text_with_model_test.py
@@ -19,7 +19,7 @@ import translate_v3_translate_text_with_model
 
 
 PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
-MODEL_ID = "TRL3128559826197068699"
+MODEL_ID = "TRL251293382528204800"
 
 
 def test_translate_text_with_model(capsys):


### PR DESCRIPTION
This PR swaps out an AutoML Translate model trained on the v1beta1 version of the service for a model trained on v1.