### PR TITLE
chore: fix 'translate' docstring return type

### DIFF
--- a/google/cloud/translate_v2/client.py
+++ b/google/cloud/translate_v2/client.py
@@ -227,7 +227,7 @@ class Client(BaseClient):
         :param model: (Optional) The model used to translate the text, such
                       as ``'base'`` or ``'nmt'``.
 
-        :rtype: str or list
+        :rtype: dict or list
         :returns: A list of dictionaries for each queried value. Each
                   dictionary typically contains three keys (though not
                   all will be present in all cases)


### PR DESCRIPTION
Fixing return type in the docstring of _translate_ method of translate_v2's Client class.

It should return a list of dictionaries, or a single dictionary. But :rtype: is set to return a str or a dict.