### PR TITLE
Fix: #254 by increasing timeout, use backoff module instead of flaky

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /samples/**/*.py                       @googleapis/cdpe-cloudai
 
 # The python-samples-owners team is the default owner for samples
-/samples/**/*.py                       @telpirion @sirtorry @googleapis/python-samples-owners
+/samples/**/*.py                       @aribray @sirtorry @googleapis/python-samples-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /samples/**/*.py                       @googleapis/cdpe-cloudai
 
 # The python-samples-owners team is the default owner for samples
-/samples/**/*.py                       @aribray @sirtorry @googleapis/python-samples-owners
+/samples/**/*.py                       @aribray @googleapis/python-samples-owners

--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
@@ -48,7 +48,11 @@ def on_backoff(invocation_dict):
     invocation_dict['kwargs']['bucket'] = next(get_ephemeral_bucket())
 
 
-@backoff.on_exception(wait_gen=lambda : iter([100, 250, 300, 500]), exception=Exception, max_tries=5, on_backoff=on_backoff)
+# If necessary, retry test function while backing off the timeout sequentially
+MAX_TIMEOUT = 500
+
+
+@backoff.on_exception(wait_gen=lambda : iter([100, 250, 300, MAX_TIMEOUT]), exception=Exception, max_tries=5, on_backoff=on_backoff)
 def test_batch_translate_text_with_glossary(capsys, bucket):
 
     translate_v3_batch_translate_text_with_glossary.batch_translate_text_with_glossary(
@@ -56,7 +60,7 @@ def test_batch_translate_text_with_glossary(capsys, bucket):
         "gs://{}/translation/BATCH_TRANSLATION_GLOS_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         GLOSSARY_ID,
-        500)
+        MAX_TIMEOUT)
 
     out, _ = capsys.readouterr()
     assert "Total Characters: 9" in out

--- a/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
+++ b/samples/snippets/translate_v3_batch_translate_text_with_glossary_test.py
@@ -15,6 +15,7 @@
 import os
 import uuid
 
+import backoff
 from google.cloud import storage
 import pytest
 
@@ -25,8 +26,7 @@ PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
 GLOSSARY_ID = "DO_NOT_DELETE_TEST_GLOSSARY"
 
 
-@pytest.fixture(scope="function")
-def bucket():
+def get_ephemeral_bucket():
     """Create a temporary bucket to store annotation output."""
     bucket_name = f"tmp-{uuid.uuid4().hex}"
     storage_client = storage.Client()
@@ -37,15 +37,26 @@ def bucket():
     bucket.delete(force=True)
 
 
-@pytest.mark.flaky(max_runs=3, min_passes=1)
+@pytest.fixture(scope="function")
+def bucket():
+    """Create a bucket feature for testing"""
+    return next(get_ephemeral_bucket())
+
+
+def on_backoff(invocation_dict):
+    """Backoff callback; create a testing bucket for each backoff run"""
+    invocation_dict['kwargs']['bucket'] = next(get_ephemeral_bucket())
+
+
+@backoff.on_exception(wait_gen=lambda : iter([100, 250, 300, 500]), exception=Exception, max_tries=5, on_backoff=on_backoff)
 def test_batch_translate_text_with_glossary(capsys, bucket):
+
     translate_v3_batch_translate_text_with_glossary.batch_translate_text_with_glossary(
         "gs://cloud-samples-data/translation/text_with_glossary.txt",
         "gs://{}/translation/BATCH_TRANSLATION_GLOS_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         GLOSSARY_ID,
-        320,
-    )
+        500)
 
     out, _ = capsys.readouterr()
     assert "Total Characters: 9" in out


### PR DESCRIPTION


Here I have moved away from "flaky" in favor of "backoff", which was already a dependency of the library.

This repository currently uses the "flaky" module/plugin to pytest to allow retries on tests. As I was trying to quantify this flakiness, I quickly realized that under-the-hood, this module uses runtime modification (monkey-patching) of the usual pytest callbacks, which breaks the interface contracts that the pytest ecosystem subscribes to and does not let me aggregate the timing statistics I need for quantifying flakiness.

The "backoff" module is already in this repo. In this PR I modify the "usual" way we set up fixtures to use the callback system from "backoff". 

Fixes #254 by increasing timeout via backoff with 4 tries: [100, 250, 300, 500]

The worst execution time was 234 seconds, so the max allowed is now 500:
Flakiness report:
```
SUCCESS
       when    duration outcome  trial
0     setup    1.524859  passed      0
1      call  141.551338  passed      0
2  teardown    0.000545  passed      0
       when    duration outcome  trial
0     setup    1.418313  passed      1
1      call  234.604837  passed      1
2  teardown    0.000532  passed      1
       when    duration outcome  trial
0     setup    1.519378  passed      2
1      call  124.333620  passed      2
2  teardown    0.000748  passed      2
       when    duration outcome  trial
0     setup    1.569923  passed      3
1      call  129.542894  passed      3
2  teardown    0.000723  passed      3
       when    duration outcome  trial
0     setup    1.459673  passed      4
1      call  125.115383  passed      4
2  teardown    0.000780  passed      4
       when   duration outcome  trial
0     setup   1.515023  passed      5
1      call  79.950361  passed      5
2  teardown   0.000626  passed      5
       when   duration outcome  trial
0     setup   1.526374  passed      6
1      call  82.278016  passed      6
2  teardown   0.001218  passed      6
       when    duration outcome  trial
0     setup    1.533906  passed      7
1      call  107.097216  passed      7
2  teardown    0.000794  passed      7
       when    duration outcome  trial
0     setup    1.417850  passed      8
1      call  136.093182  passed      8
2  teardown    0.000509  passed      8
       when    duration outcome  trial
0     setup    1.433857  passed      9
1      call  134.896833  passed      9
2  teardown    0.000841  passed      9
```
