### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "translation",
     "name_pretty": "Cloud Translation",
     "product_documentation": "https://cloud.google.com/translate/docs/",
-    "client_documentation": "https://googleapis.dev/python/translation/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/translation/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559749",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Cloud Translation is available as a paid service. See the `Pricing`_ and
 .. _Google Cloud Translation: https://cloud.google.com/translate/
 .. _Pricing: https://cloud.google.com/translate/pricing
 .. _FAQ: https://cloud.google.com/translate/faq
-.. _Client Library Documentation: https://googleapis.dev/python/translation/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/translation/latest
 .. _Product Documentation: https://cloud.google.com/translate/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.