### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-translate"
-copyright = u"2017, Google"
-author = u"Google APIs"
+project = "google-cloud-translate"
+copyright = "2017, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -259,7 +259,7 @@ latex_documents = [
     (
         master_doc,
         "google-cloud-translate.tex",
-        u"google-cloud-translate Documentation",
+        "google-cloud-translate Documentation",
         author,
         "manual",
     )
@@ -293,7 +293,7 @@ man_pages = [
     (
         master_doc,
         "google-cloud-translate",
-        u"google-cloud-translate Documentation",
+        "google-cloud-translate Documentation",
         [author],
         1,
     )
@@ -311,7 +311,7 @@ texinfo_documents = [
     (
         master_doc,
         "google-cloud-translate",
-        u"google-cloud-translate Documentation",
+        "google-cloud-translate Documentation",
         author,
         "google-cloud-translate",
         "GAPIC library for the {metadata.shortName} v3beta1 service",

--- a/google/cloud/translate_v3/gapic/translation_service_client.py
+++ b/google/cloud/translate_v3/gapic/translation_service_client.py
@@ -183,8 +183,10 @@ class TranslationServiceClient(object):
                     )
                 self.transport = transport
         else:
-            self.transport = translation_service_grpc_transport.TranslationServiceGrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials
+            self.transport = (
+                translation_service_grpc_transport.TranslationServiceGrpcTransport(
+                    address=api_endpoint, channel=channel, credentials=credentials
+                )
             )
 
         if client_info is None:

--- a/google/cloud/translate_v3/proto/translation_service_pb2_grpc.py
+++ b/google/cloud/translate_v3/proto/translation_service_pb2_grpc.py
@@ -12,15 +12,15 @@ from google.longrunning import (
 class TranslationServiceStub(object):
     """Proto file for the Cloud Translation API (v3 GA).
 
-  Provides natural language translation operations.
-  """
+    Provides natural language translation operations.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.TranslateText = channel.unary_unary(
             "/google.cloud.translation.v3.TranslationService/TranslateText",
             request_serializer=google_dot_cloud_dot_translation__v3_dot_proto_dot_translation__service__pb2.TranslateTextRequest.SerializeToString,
@@ -66,72 +66,69 @@ class TranslationServiceStub(object):
 class TranslationServiceServicer(object):
     """Proto file for the Cloud Translation API (v3 GA).
 
-  Provides natural language translation operations.
-  """
+    Provides natural language translation operations.
+    """
 
     def TranslateText(self, request, context):
-        """Translates input text and returns translated text.
-    """
+        """Translates input text and returns translated text."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DetectLanguage(self, request, context):
-        """Detects the language of text within a request.
-    """
+        """Detects the language of text within a request."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetSupportedLanguages(self, request, context):
-        """Returns a list of supported languages for translation.
-    """
+        """Returns a list of supported languages for translation."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def BatchTranslateText(self, request, context):
         """Translates a large volume of text in asynchronous batch mode.
-    This function provides real-time output as the inputs are being processed.
-    If caller cancels a request, the partial results (for an input file, it's
-    all or nothing) may still be available on the specified output location.
+        This function provides real-time output as the inputs are being processed.
+        If caller cancels a request, the partial results (for an input file, it's
+        all or nothing) may still be available on the specified output location.
 
-    This call returns immediately and you can
-    use google.longrunning.Operation.name to poll the status of the call.
-    """
+        This call returns immediately and you can
+        use google.longrunning.Operation.name to poll the status of the call.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateGlossary(self, request, context):
         """Creates a glossary and returns the long-running operation. Returns
-    NOT_FOUND, if the project doesn't exist.
-    """
+        NOT_FOUND, if the project doesn't exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListGlossaries(self, request, context):
         """Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
-    exist.
-    """
+        exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetGlossary(self, request, context):
         """Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
-    exist.
-    """
+        exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteGlossary(self, request, context):
         """Deletes a glossary, or cancels glossary construction
-    if the glossary isn't created yet.
-    Returns NOT_FOUND, if the glossary doesn't exist.
-    """
+        if the glossary isn't created yet.
+        Returns NOT_FOUND, if the glossary doesn't exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/translate_v3beta1/gapic/translation_service_client.py
+++ b/google/cloud/translate_v3beta1/gapic/translation_service_client.py
@@ -183,8 +183,10 @@ class TranslationServiceClient(object):
                     )
                 self.transport = transport
         else:
-            self.transport = translation_service_grpc_transport.TranslationServiceGrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials
+            self.transport = (
+                translation_service_grpc_transport.TranslationServiceGrpcTransport(
+                    address=api_endpoint, channel=channel, credentials=credentials
+                )
             )
 
         if client_info is None:

--- a/google/cloud/translate_v3beta1/proto/translation_service_pb2_grpc.py
+++ b/google/cloud/translate_v3beta1/proto/translation_service_pb2_grpc.py
@@ -12,15 +12,15 @@ from google.longrunning import (
 class TranslationServiceStub(object):
     """Proto file for the Cloud Translation API (v3beta1).
 
-  Provides natural language translation operations.
-  """
+    Provides natural language translation operations.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.TranslateText = channel.unary_unary(
             "/google.cloud.translation.v3beta1.TranslationService/TranslateText",
             request_serializer=google_dot_cloud_dot_translation__v3beta1_dot_proto_dot_translation__service__pb2.TranslateTextRequest.SerializeToString,
@@ -66,72 +66,69 @@ class TranslationServiceStub(object):
 class TranslationServiceServicer(object):
     """Proto file for the Cloud Translation API (v3beta1).
 
-  Provides natural language translation operations.
-  """
+    Provides natural language translation operations.
+    """
 
     def TranslateText(self, request, context):
-        """Translates input text and returns translated text.
-    """
+        """Translates input text and returns translated text."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DetectLanguage(self, request, context):
-        """Detects the language of text within a request.
-    """
+        """Detects the language of text within a request."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetSupportedLanguages(self, request, context):
-        """Returns a list of supported languages for translation.
-    """
+        """Returns a list of supported languages for translation."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def BatchTranslateText(self, request, context):
         """Translates a large volume of text in asynchronous batch mode.
-    This function provides real-time output as the inputs are being processed.
-    If caller cancels a request, the partial results (for an input file, it's
-    all or nothing) may still be available on the specified output location.
+        This function provides real-time output as the inputs are being processed.
+        If caller cancels a request, the partial results (for an input file, it's
+        all or nothing) may still be available on the specified output location.
 
-    This call returns immediately and you can
-    use google.longrunning.Operation.name to poll the status of the call.
-    """
+        This call returns immediately and you can
+        use google.longrunning.Operation.name to poll the status of the call.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateGlossary(self, request, context):
         """Creates a glossary and returns the long-running operation. Returns
-    NOT_FOUND, if the project doesn't exist.
-    """
+        NOT_FOUND, if the project doesn't exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListGlossaries(self, request, context):
         """Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
-    exist.
-    """
+        exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetGlossary(self, request, context):
         """Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
-    exist.
-    """
+        exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteGlossary(self, request, context):
         """Deletes a glossary, or cancels glossary construction
-    if the glossary isn't created yet.
-    Returns NOT_FOUND, if the glossary doesn't exist.
-    """
+        if the glossary isn't created yet.
+        Returns NOT_FOUND, if the glossary doesn't exist.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.3b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 if os.path.exists("samples"):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "1.7.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 1.0.3, < 2.0dev",
 ]
 extras = {}

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "1.7.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "google-cloud-core >= 1.0.3, < 2.0dev",
+    "google-cloud-core >= 1.0.3, < 3.0dev",
 ]
 extras = {}
 

--- a/tests/system.py
+++ b/tests/system.py
@@ -46,7 +46,7 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(lang_map["zu"], "Zulu")
 
     def test_detect_language(self):
-        values = ["takoy", u"fa\xe7ade", "s'il vous plait"]
+        values = ["takoy", "fa\xe7ade", "s'il vous plait"]
         detections = Config.CLIENT.detect_language(values)
         self.assertEqual(len(values), len(detections))
         self.assertEqual(detections[0]["language"], "ru")
@@ -61,13 +61,13 @@ class TestTranslate(unittest.TestCase):
         self.assertEqual(len(values), len(translations))
 
         self.assertEqual(translations[0]["detectedSourceLanguage"].lower(), "hr")
-        self.assertEqual(translations[0]["translatedText"].lower(), u"fünfzehn")
+        self.assertEqual(translations[0]["translatedText"].lower(), "fünfzehn")
 
         self.assertEqual(translations[1]["detectedSourceLanguage"], "eo")
-        self.assertEqual(translations[1]["translatedText"].lower(), u"fünfzehn")
+        self.assertEqual(translations[1]["translatedText"].lower(), "fünfzehn")
 
         self.assertEqual(translations[2]["detectedSourceLanguage"], "es")
-        self.assertEqual(translations[2]["translatedText"].lower(), u"ich heiße jeff")
+        self.assertEqual(translations[2]["translatedText"].lower(), "ich heiße jeff")
 
         self.assertEqual(translations[3]["detectedSourceLanguage"], "en")
         self.assertEqual(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -199,7 +199,7 @@ class TestClient(unittest.TestCase):
 
     def test_detect_language_multiple_values(self):
         client = self._make_one(_http=object())
-        value1 = u"fa\xe7ade"  # facade (with a cedilla)
+        value1 = "fa\xe7ade"  # facade (with a cedilla)
         detection1 = {
             "confidence": 0.6166008,
             "input": value1,


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566